### PR TITLE
Added some additional rpc commands to support zcashd monitoring

### DIFF
--- a/pyZcash/rpc/ZDaemon.py
+++ b/pyZcash/rpc/ZDaemon.py
@@ -42,7 +42,7 @@ class ZDaemon(object):
 	def getBlockByHash(self, blockhash):
 		return self._call('getblock', blockhash)
 
-	def getrawtransaction(self, txid):
+	def getRawTransaction(self, txid):
 		return self._call('getrawtransaction', txid, 1)
 
 	def getBlockByHeight(self, blockheight):
@@ -52,19 +52,19 @@ class ZDaemon(object):
 	def getNetworkHeight(self):
 		return self._call('getblockcount')
 
-	def getinfo(self):
+	def getInfo(self):
 		return self._call('getinfo')
 
-	def getchaintips(self):
+	def getChainTips(self):
 		return self._call('getchaintips')
 
-	def getmempoolinfo(self):
+	def getMempoolInfo(self):
 		return self._call('getmempoolinfo')
 
-	def getnetworksolps(self):
+	def getNetworkSolps(self):
 		return self._call('getnetworksolps')
 
-	def getnettotals(self):
+	def getNetTotals(self):
 		return self._call('getnettotals')
 
 	def getNetworkDifficulty(self):

--- a/pyZcash/rpc/ZDaemon.py
+++ b/pyZcash/rpc/ZDaemon.py
@@ -42,12 +42,30 @@ class ZDaemon(object):
 	def getBlockByHash(self, blockhash):
 		return self._call('getblock', blockhash)
 
+	def getrawtransaction(self, txid):
+		return self._call('getrawtransaction', txid, 1)
+
 	def getBlockByHeight(self, blockheight):
 		return self.getBlockByHash(self.getBlockHash(blockheight))
 
 	# Custom methods to get Network Info
 	def getNetworkHeight(self):
 		return self._call('getblockcount')
+
+	def getinfo(self):
+		return self._call('getinfo')
+
+	def getchaintips(self):
+		return self._call('getchaintips')
+
+	def getmempoolinfo(self):
+		return self._call('getmempoolinfo')
+
+	def getnetworksolps(self):
+		return self._call('getnetworksolps')
+
+	def getnettotals(self):
+		return self._call('getnettotals')
 
 	def getNetworkDifficulty(self):
 		return self._call('getdifficulty')


### PR DESCRIPTION
Just some additional rpc commands. Preserved rpc command format.

These rpc commands are required to move the zcashd_monitor.py script from local `zcash-cli` to remote rpc usage.

